### PR TITLE
fix: missing thread include

### DIFF
--- a/include/item_reader.hpp
+++ b/include/item_reader.hpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <mutex>
 #include <condition_variable>
+#include <thread>
 #include "item.hpp"
 #include "logger.hpp"
 #include "event_dispatch.hpp"

--- a/include/item_sorter.hpp
+++ b/include/item_sorter.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <fstream>
 #include <mutex>
+#include <thread>
 
 class ItemSorter : public EventListener {
 public:


### PR DESCRIPTION
Compilation fails on my system because of the missing `<thread>` include