### PR TITLE
fix: ui thread consumes 100% cpu when idle

### DIFF
--- a/src/user_interface.cpp
+++ b/src/user_interface.cpp
@@ -251,7 +251,9 @@ void UserInterface::onLoop() {
     focusEditor();
     fflush(m_outputFile);
 
-    if (remaining > 0ms) {
+    if (!m_spinner.isSpinning()) {
+        awaitEvent();
+    } else if (remaining > 0ms) {
         awaitEvent(remaining);
     }
 }


### PR DESCRIPTION
UI thread was spinning at 100% CPU when there was no actual work to do. When spinner is not running, the "remaining" variable is always zero, which skipped the awaitEvent call entirely.