### PR TITLE
perf: remove std::function in ItemSorter::sort

### DIFF
--- a/src/item_sorter.cpp
+++ b/src/item_sorter.cpp
@@ -19,7 +19,7 @@ ItemSorter::ItemSorter() {
     m_dispatch.subscribe(this, QUIT_EVENT);
 }
 
-bool sortFunc(Item& l, Item& r) {
+static bool sortFunc(const Item& l, const Item& r) {
     if (l.heuristic == r.heuristic) {
         if (strlen(l.text) == strlen(r.text)) {
             return l.index < r.index;
@@ -29,7 +29,7 @@ bool sortFunc(Item& l, Item& r) {
     return l.heuristic > r.heuristic;
 }
 
-bool sortEmptyFunc(Item& l, Item& r) {
+static bool sortEmptyFunc(const Item& l, const Item& r) {
     return l.index < r.index;
 }
 
@@ -40,13 +40,18 @@ void ItemSorter::sort(int sortIdx) {
     if (sortIdx > m_items.size()) {
         sortIdx = m_items.size();
     }
-    std::function<bool(Item& l, Item &r)> f;
-    f = m_isSorted ? sortFunc : sortEmptyFunc;
 
     m_logger.log("sorting from %d to %d", m_sortIdx, sortIdx);
 
-    std::partial_sort(m_items.begin() + m_sortIdx,
-            m_items.begin() + sortIdx, m_items.end(), f);
+    auto first = m_items.begin() + m_sortIdx;
+    auto middle = m_items.begin() + sortIdx;
+    auto last = m_items.end();
+    if (m_isSorted) {
+        std::partial_sort(first, middle, last, sortFunc);
+    } else {
+        std::partial_sort(first, middle, last, sortEmptyFunc);
+    }
+
     m_sortIdx = sortIdx;
 }
 


### PR DESCRIPTION
std::function can store any type of function, including for example functions that have state. Because compilers can't figure out at compile time what type of function is it going to be or how much memory is going to be needed to store the state, std::function resorts to polymorphism, which can have quite big runtime cost.

std::function can be a good thing if you want to provide a customization point in a library, but it should be avoided in high performance code.

I can't tell how much overall performance impact it has here, because there are no benchmarks to measure it, but I ran some micro benchmarks with just std::sort. Using normal function pointers on my machine is 1.5x faster than the baseline std::function solution:

    std::sort(begin, end, cond ? func1 : func2);

And pulling it out to separate branches (like in the PR) is 2x faster:

    if (cond) {
        std::sort(begin, end, func1);
    } else {
        std::sort(begin, end, func2);
    }

Additionally, compare functions are now marked as static, so the compiler knows that they are visible only to this file, which can potentially enable more optimizations like function inlining.