### PR TITLE
refactor

### DIFF
--- a/include/ansi_style.hpp
+++ b/include/ansi_style.hpp
@@ -35,7 +35,7 @@ class AnsiStyle {
         AnsiStyle& strikethrough();
         AnsiStyle& dim();
         AnsiStyle& underline(UnderlineType type);
-        std::string build();
+        std::string build() const;
 
     private:
         ColorType m_fgType = NO_COLOR;

--- a/include/ansi_wrapper.hpp
+++ b/include/ansi_wrapper.hpp
@@ -1,15 +1,18 @@
 #ifndef ANSI_WRAPPER_HPP
 #define ANSI_WRAPPER_HPP
 
+#include <cstdint>
+#include <cstddef>
+#include <cstdlib>
+#include <cstdio>
+#include <csignal>
+#include <cstdbool>
+
+extern "C" {
 #include <unistd.h>
-#include <stdint.h>
-#include <stddef.h>
 #include <sys/ioctl.h>
 #include <termios.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <signal.h>
-#include <stdbool.h>
+}
 
 
 class AnsiWrapper {

--- a/include/ansi_wrapper.hpp
+++ b/include/ansi_wrapper.hpp
@@ -28,40 +28,40 @@ public:
     void setInputFileNo(int fileNo);
     void setOutputFile(FILE *file);
 
-    void move(unsigned int x, unsigned int y);
-    void moveHome();
+    void move(unsigned int x, unsigned int y) const;
+    void moveHome() const;
 
-    void moveUp();
-    void moveDown();
-    void moveLeft();
-    void moveRight();
+    void moveUp() const;
+    void moveDown() const;
+    void moveLeft() const;
+    void moveRight() const;
 
-    void moveUp(unsigned int amount);
-    void moveDown(unsigned int amount);
-    void moveLeft(unsigned int amount);
-    void moveRight(unsigned int amount);
+    void moveUp(unsigned int amount) const;
+    void moveDown(unsigned int amount) const;
+    void moveLeft(unsigned int amount) const;
+    void moveRight(unsigned int amount) const;
 
-    void moveUpOrScroll();
-    void moveDownOrScroll();
+    void moveUpOrScroll() const;
+    void moveDownOrScroll() const;
 
-    void clearTerm();
-    void clearTilEOL();
-    void clearTilSOF();
-    void clearTilEOF();
+    void clearTerm() const;
+    void clearTilEOL() const;
+    void clearTilSOF() const;
+    void clearTilEOF() const;
 
     void enableMouse();
     void disableMouse();
 
     void setAlternateBuffer(bool value);
-    void setCursor(bool value);
+    void setCursor(bool value) const;
     void setCtrlC(bool value);
 
     void initTerm();
     void initTermSimple();
     void restoreTerm();
 
-    void saveCursor();
-    void restoreCursor();
+    void saveCursor() const;
+    void restoreCursor() const;
 
     void closeStdin();
 };

--- a/include/config_json_reader.hpp
+++ b/include/config_json_reader.hpp
@@ -9,8 +9,8 @@
 class ConfigJsonReader {
     public:
         bool read(std::ifstream &ifs);
-        std::string& getError();
-        int getErrorLine();
+        const std::string& getError() const;
+        int getErrorLine() const;
         ConfigJsonReader(StyleManager *styleManager);
 
     private:

--- a/include/event.hpp
+++ b/include/event.hpp
@@ -45,7 +45,7 @@ public:
         m_mouseEvents = mouseEvents;
     }
 
-    EventType getType() const {
+    EventType getType() const override {
         return KEY_EVENT;
     }
 
@@ -70,7 +70,7 @@ public:
         m_query = query;
     }
 
-    EventType getType() const {
+    EventType getType() const override {
         return QUERY_CHANGE_EVENT;
     }
 
@@ -87,7 +87,7 @@ public:
         m_items = items;
     }
 
-    EventType getType() const {
+    EventType getType() const override {
         return NEW_ITEMS_EVENT;
     }
 
@@ -97,25 +97,25 @@ public:
 };
 
 class AllItemsReadEvent : public Event {
-    EventType getType() const {
+    EventType getType() const override {
         return ALL_ITEMS_READ_EVENT;
     }
 };
 
 class QuitEvent : public Event {
-    EventType getType() const {
+    EventType getType() const override {
         return QUIT_EVENT;
     }
 };
 
 class ItemsAddedEvent : public Event {
-    EventType getType() const {
+    EventType getType() const override {
         return ITEMS_ADDED_EVENT;
     }
 };
 
 class ItemsSortedEvent : public Event {
-    EventType getType() const {
+    EventType getType() const override {
         return ITEMS_SORTED_EVENT;
     }
 };
@@ -130,7 +130,7 @@ public:
         m_height = height;
     }
 
-    EventType getType() const {
+    EventType getType() const override {
         return RESIZE_EVENT;
     }
 

--- a/include/event.hpp
+++ b/include/event.hpp
@@ -17,12 +17,12 @@ enum EventType {
     RESIZE_EVENT,
     QUIT_EVENT,
 };
-const char** getEventNames();
+const char* const* getEventNames();
 
 class Event {
 public:
     virtual ~Event() {}
-    virtual EventType getType() = 0;
+    virtual EventType getType() const = 0;
 };
 
 class KeyEvent : public Event {
@@ -45,7 +45,7 @@ public:
         m_mouseEvents = mouseEvents;
     }
 
-    EventType getType() {
+    EventType getType() const {
         return KEY_EVENT;
     }
 
@@ -70,7 +70,7 @@ public:
         m_query = query;
     }
 
-    EventType getType() {
+    EventType getType() const {
         return QUERY_CHANGE_EVENT;
     }
 
@@ -87,7 +87,7 @@ public:
         m_items = items;
     }
 
-    EventType getType() {
+    EventType getType() const {
         return NEW_ITEMS_EVENT;
     }
 
@@ -97,25 +97,25 @@ public:
 };
 
 class AllItemsReadEvent : public Event {
-    EventType getType() {
+    EventType getType() const {
         return ALL_ITEMS_READ_EVENT;
     }
 };
 
 class QuitEvent : public Event {
-    EventType getType() {
+    EventType getType() const {
         return QUIT_EVENT;
     }
 };
 
 class ItemsAddedEvent : public Event {
-    EventType getType() {
+    EventType getType() const {
         return ITEMS_ADDED_EVENT;
     }
 };
 
 class ItemsSortedEvent : public Event {
-    EventType getType() {
+    EventType getType() const {
         return ITEMS_SORTED_EVENT;
     }
 };
@@ -130,15 +130,15 @@ public:
         m_height = height;
     }
 
-    EventType getType() {
+    EventType getType() const {
         return RESIZE_EVENT;
     }
 
-    int getWidth() {
+    int getWidth() const {
         return m_width;
     }
 
-    int getHeight() {
+    int getHeight() const {
         return m_height;
     }
 };

--- a/include/input_reader.hpp
+++ b/include/input_reader.hpp
@@ -21,9 +21,9 @@ public:
     bool hasKey();
     void setFileDescriptor(int fileDescriptor);
 
-    void onLoop();
-    void preOnEvent(EventType type);
-    void onEvent(std::shared_ptr<Event> event);
+    void onLoop() override;
+    void preOnEvent(EventType type) override;
+    void onEvent(std::shared_ptr<Event> event) override;
 
     void onSigInt();
 

--- a/include/input_reader.hpp
+++ b/include/input_reader.hpp
@@ -5,10 +5,14 @@
 #include "event_dispatch.hpp"
 #include "mouse_event.hpp"
 #include "logger.hpp"
+
 #include <string>
 #include <vector>
-#include <sys/select.h>
 #include <thread>
+
+extern "C" {
+#include <sys/select.h>
+}
 
 bool isContinuationByte(unsigned char ch);
 int utf8CharLen(unsigned char ch);

--- a/include/item_cache.hpp
+++ b/include/item_cache.hpp
@@ -10,8 +10,8 @@ class ItemCache {
         ItemCache(ItemSorter *sorter);
         void refresh();
         Item* get(int i);
-        int size();
-        int getReserve();
+        int size() const;
+        int getReserve() const;
         void setReserve(int n);
 
     private:

--- a/include/item_list.hpp
+++ b/include/item_list.hpp
@@ -30,10 +30,9 @@ class ItemList {
     AnsiWrapper &ansi = AnsiWrapper::instance();
     Config& m_config = Config::instance();
 
-    void drawItem();
-    void drawName(int i);
-    void drawHint(int i);
-    void drawItems();
+    void drawName(int i) const;
+    void drawHint(int i) const;
+    void drawItems() const;
     void calcVisibleItems();
 
 public:
@@ -42,8 +41,8 @@ public:
     void allowScrolling(bool value);
     bool didScroll();
     void setSelected(int y);
-    Item* getSelected();
-    Item* get(int y);
+    Item* getSelected() const;
+    Item* get(int y) const;
     void resize(int w, int h);
     void scrollUp();
     void scrollDown();

--- a/include/item_reader.hpp
+++ b/include/item_reader.hpp
@@ -16,9 +16,9 @@ public:
     ItemReader(FILE *file);
     void setReadHints(bool readHints);
     bool read();
-    void onStart();
-    void onLoop();
-    void onEvent(std::shared_ptr<Event> event);
+    void onStart() override;
+    void onLoop() override;
+    void onEvent(std::shared_ptr<Event> event) override;
     void dispatchItems();
 
 private:

--- a/include/item_reader.hpp
+++ b/include/item_reader.hpp
@@ -2,7 +2,7 @@
 #define ITEM_READER_HPP
 
 #include <vector>
-#include <stdio.h>
+#include <cstdio>
 #include <mutex>
 #include <condition_variable>
 #include <thread>

--- a/include/item_sorter.hpp
+++ b/include/item_sorter.hpp
@@ -12,7 +12,7 @@
 class ItemSorter : public EventListener {
 public:
     ItemSorter();
-    int size();
+    int size() const;
     int copyItems(Item *buffer, int idx, int n);
     void onEvent(std::shared_ptr<Event> event);
     void onLoop();

--- a/include/item_sorter.hpp
+++ b/include/item_sorter.hpp
@@ -14,9 +14,9 @@ public:
     ItemSorter();
     int size() const;
     int copyItems(Item *buffer, int idx, int n);
-    void onEvent(std::shared_ptr<Event> event);
-    void onLoop();
-    void onStart();
+    void onEvent(std::shared_ptr<Event> event) override;
+    void onLoop() override;
+    void onStart() override;
 
 private:
     bool m_sorterThreadActive = false;

--- a/include/json_parser.hpp
+++ b/include/json_parser.hpp
@@ -17,8 +17,8 @@ enum JsonElementType {
 class JsonElement {
     public:
         virtual std::string repr(int indent, int depth) = 0;
-        JsonElementType getType();
-        int getLine();
+        JsonElementType getType() const;
+        int getLine() const;
 
     protected:
         JsonElementType m_type;
@@ -95,9 +95,9 @@ class JsonArray : public JsonElement {
 class JsonParser {
     public:
         bool parse(std::string json);
-        std::string getError();
-        JsonElement* getElement();
-        int getLine();
+        std::string getError() const;
+        JsonElement* getElement() const;
+        int getLine() const;
 
     private:
         std::string m_error;

--- a/include/json_parser.hpp
+++ b/include/json_parser.hpp
@@ -30,7 +30,7 @@ class JsonString : public JsonElement {
     public:
         JsonString(int line, int idx, std::string value);
         std::string& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         std::string m_value;
@@ -40,7 +40,7 @@ class JsonInt : public JsonElement {
     public:
         JsonInt(int line, int idx, int value);
         int& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         int m_value;
@@ -50,7 +50,7 @@ class JsonFloat : public JsonElement {
     public:
         JsonFloat(int line, int idx, double value);
         double& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         double m_value;
@@ -60,7 +60,7 @@ class JsonBoolean : public JsonElement {
     public:
         JsonBoolean(int line, int idx, bool value);
         bool& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         bool m_value;
@@ -75,7 +75,7 @@ class JsonObject : public JsonElement {
     public:
         JsonObject(int line, int idx);
         std::map<std::string, JsonObjectEntry>& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         std::map<std::string, JsonObjectEntry> m_value;
@@ -85,7 +85,7 @@ class JsonArray : public JsonElement {
     public:
         JsonArray(int line, int idx);
         std::vector<JsonElement*>& getValue();
-        std::string repr(int indent, int depth);
+        std::string repr(int indent, int depth) override;
 
     private:
         std::vector<JsonElement*> m_value;

--- a/include/json_reader.hpp
+++ b/include/json_reader.hpp
@@ -67,7 +67,7 @@ class JsonReader {
     public:
         JsonReader(std::map<std::string, JsonReaderStrategy*>& options);
         bool read(JsonElement *element);
-        static std::string& getError();
+        static const std::string& getError();
         static int getErrorLine();
 
     private:

--- a/include/json_reader.hpp
+++ b/include/json_reader.hpp
@@ -17,7 +17,7 @@ class JsonStringReaderStrategy : public JsonReaderStrategy {
         JsonStringReaderStrategy(std::string *value);
         JsonStringReaderStrategy* min(int minLen);
         JsonStringReaderStrategy* max(int maxLen);
-        bool read(const std::string& name, JsonElement *element);
+        bool read(const std::string& name, JsonElement *element) override;
 
     private:
         std::string* m_value;
@@ -30,7 +30,7 @@ class JsonIntReaderStrategy : public JsonReaderStrategy {
         JsonIntReaderStrategy(int *value);
         JsonIntReaderStrategy* min(int min);
         JsonIntReaderStrategy* max(int max);
-        bool read(const std::string& name, JsonElement *element);
+        bool read(const std::string& name, JsonElement *element) override;
 
     private:
         int* m_value;
@@ -41,7 +41,7 @@ class JsonIntReaderStrategy : public JsonReaderStrategy {
 class JsonBoolReaderStrategy : public JsonReaderStrategy {
     public:
         JsonBoolReaderStrategy(bool *value);
-        bool read(const std::string& name, JsonElement *element);
+        bool read(const std::string& name, JsonElement *element) override;
 
     private:
         bool* m_value;
@@ -51,7 +51,7 @@ class JsonStylesReaderStrategy : public JsonReaderStrategy {
     public:
         JsonStylesReaderStrategy(StyleManager *styleManager,
                 std::map<std::string, int*>& styles);
-        bool read(const std::string& name, JsonElement *element);
+        bool read(const std::string& name, JsonElement *element) override;
         bool readStyle(JsonElement *element, AnsiStyle *style);
         bool readColorRGB(ColorRGB *color, JsonString *str);
         bool readColor16(Color16 *color, JsonString *str);

--- a/include/option.hpp
+++ b/include/option.hpp
@@ -18,7 +18,7 @@ class BooleanOption : public Option {
     public:
         BooleanOption(std::string key, bool *value);
         BooleanOption* defaultTrue();
-        bool parse(const char *value);
+        bool parse(const char *value) override;
 
     private:
         bool *m_value;
@@ -29,7 +29,7 @@ class StringOption : public Option {
     public:
         StringOption(std::string key, std::string *value);
         StringOption* nonEmpty();
-        bool parse(const char *value);
+        bool parse(const char *value) override;
 
     private:
         std::string *m_value;
@@ -41,7 +41,7 @@ class IntegerOption : public Option {
         IntegerOption(std::string key, int *value);
         IntegerOption* min(int min);
         IntegerOption* max(int max);
-        bool parse(const char *value);
+        bool parse(const char *value) override;
 
     private:
         std::optional<int> m_min;

--- a/include/option.hpp
+++ b/include/option.hpp
@@ -6,12 +6,12 @@
 
 class Option {
     public:
-        const std::string& getKey();
+        const std::string& getKey() const;
         virtual bool parse(const char *value) = 0;
 
     protected:
         std::string m_key;
-        bool error(std::string message);
+        bool error(const std::string& message) const;
 };
 
 class BooleanOption : public Option {

--- a/include/sliding_cache.hpp
+++ b/include/sliding_cache.hpp
@@ -60,7 +60,7 @@ class SlidingCache {
             refresh(0);
         }
 
-        int getReserve() {
+        int getReserve() const {
             return m_reserve;
         }
 

--- a/include/spinner.hpp
+++ b/include/spinner.hpp
@@ -21,10 +21,10 @@ class Spinner {
 public:
     Spinner(FILE *file);
     void setPosition(int x, int y);
-    std::chrono::milliseconds frameTimeRemaining();
+    std::chrono::milliseconds frameTimeRemaining() const;
     void update();
-    void draw();
-    bool isSpinning();
+    void draw() const;
+    bool isSpinning() const;
     void setSpinning(bool value);
 };
 

--- a/include/user_interface.hpp
+++ b/include/user_interface.hpp
@@ -16,8 +16,8 @@ public:
             ItemList *itemLis, Utf8LineEditor *editor);
     void handleInput(KeyEvent event);
     Item* getSelected() const;
-    void onEvent(std::shared_ptr<Event> event);
-    void onLoop();
+    void onEvent(std::shared_ptr<Event> event) override;
+    void onLoop() override;
 
 private:
     void redraw();

--- a/include/user_interface.hpp
+++ b/include/user_interface.hpp
@@ -15,7 +15,7 @@ public:
     UserInterface(FILE *outputFile, StyleManager *styleManager,
             ItemList *itemLis, Utf8LineEditor *editor);
     void handleInput(KeyEvent event);
-    Item* getSelected();
+    Item* getSelected() const;
     void onEvent(std::shared_ptr<Event> event);
     void onLoop();
 

--- a/include/utf8_line_editor.hpp
+++ b/include/utf8_line_editor.hpp
@@ -9,7 +9,7 @@
 class Utf8LineEditor {
     public:
         Utf8LineEditor(FILE *outputFile);
-        bool requiresRedraw();
+        bool requiresRedraw() const;
         void print();
         void input(char ch);
         void input(std::string text);
@@ -19,8 +19,8 @@ class Utf8LineEditor {
         void moveCursorLeft();
         void moveCursorRight();
         void clear();
-        std::string& getText();
-        int getCursorCol();
+        const std::string& getText() const;
+        int getCursorCol() const;
         void setWidth(int width);
 
     private:

--- a/include/utf8_string.hpp
+++ b/include/utf8_string.hpp
@@ -14,9 +14,9 @@ struct Utf8String {
 
 class Utf8StringCursor {
     public:
-        int getByte();
-        int getIdx();
-        int getCol();
+        int getByte() const;
+        int getIdx() const;
+        int getCol() const;
         void setString(Utf8String *str);
         void insert(char ch);
         void insert(std::string& str);
@@ -26,7 +26,7 @@ class Utf8StringCursor {
         bool del();
         void reset();
         int getBytesForCols(int cols);
-        const char* getPointer();
+        const char* getPointer() const;
 
     private:
         Utf8String *m_str;

--- a/src/ansi_style.cpp
+++ b/src/ansi_style.cpp
@@ -77,7 +77,7 @@ AnsiStyle& AnsiStyle::underline(UnderlineType type) {
     return *this;
 }
 
-std::string AnsiStyle::build() {
+std::string AnsiStyle::build() const {
     std::stringstream ss;
     ss << "\x1b[0";
 

--- a/src/ansi_wrapper.cpp
+++ b/src/ansi_wrapper.cpp
@@ -17,51 +17,51 @@ AnsiWrapper& AnsiWrapper::instance() {
     return singleton;
 }
 
-void AnsiWrapper::move(unsigned int x, unsigned int y) {
+void AnsiWrapper::move(unsigned int x, unsigned int y) const {
     fprintf(m_outputFile, ANSI_ESC "%u;%uH", y + 1, x + 1);
 }
 
-void AnsiWrapper::moveHome() {
+void AnsiWrapper::moveHome() const {
     fprintf(m_outputFile, ANSI_ESC "H");
 }
 
-void AnsiWrapper::moveUp() {
+void AnsiWrapper::moveUp() const {
     fprintf(m_outputFile, ANSI_ESC "A");
 }
 
-void AnsiWrapper::moveDown() {
+void AnsiWrapper::moveDown() const {
     fprintf(m_outputFile, ANSI_ESC "B");
 }
 
-void AnsiWrapper::moveRight() {
+void AnsiWrapper::moveRight() const {
     fprintf(m_outputFile, ANSI_ESC "C");
 }
 
-void AnsiWrapper::moveLeft() {
+void AnsiWrapper::moveLeft() const {
     fprintf(m_outputFile, ANSI_ESC "D");
 }
 
-void AnsiWrapper::moveUp(unsigned int amount) {
+void AnsiWrapper::moveUp(unsigned int amount) const {
     fprintf(m_outputFile, ANSI_ESC "%uA", amount);
 }
 
-void AnsiWrapper::moveDown(unsigned int amount) {
+void AnsiWrapper::moveDown(unsigned int amount) const {
     fprintf(m_outputFile, ANSI_ESC "%uB", amount);
 }
 
-void AnsiWrapper::moveRight(unsigned int amount) {
+void AnsiWrapper::moveRight(unsigned int amount) const {
     fprintf(m_outputFile, ANSI_ESC "%uC", amount);
 }
 
-void AnsiWrapper::moveLeft(unsigned int amount) {
+void AnsiWrapper::moveLeft(unsigned int amount) const {
     fprintf(m_outputFile, ANSI_ESC "%uD", amount);
 }
 
-void AnsiWrapper::moveUpOrScroll() {
+void AnsiWrapper::moveUpOrScroll() const {
     fprintf(m_outputFile, "\x1bM");
 }
 
-void AnsiWrapper::moveDownOrScroll() {
+void AnsiWrapper::moveDownOrScroll() const {
     fprintf(m_outputFile, "\n");
 }
 
@@ -87,23 +87,23 @@ void AnsiWrapper::setAlternateBuffer(bool value) {
     fprintf(m_outputFile, ANSI_ESC "?1049%c", value ? 'h' : 'l');
 }
 
-void AnsiWrapper::clearTilEOL() {
+void AnsiWrapper::clearTilEOL() const {
     fprintf(m_outputFile, ANSI_ESC "K");
 }
 
-void AnsiWrapper::clearTilSOF() {
+void AnsiWrapper::clearTilSOF() const {
     fprintf(m_outputFile, ANSI_ESC "1J");
 }
 
-void AnsiWrapper::clearTilEOF() {
+void AnsiWrapper::clearTilEOF() const {
     fprintf(m_outputFile, ANSI_ESC "2J");
 }
 
-void AnsiWrapper::clearTerm() {
+void AnsiWrapper::clearTerm() const {
     fprintf(m_outputFile, ANSI_ESC "2J");
 }
 
-void AnsiWrapper::setCursor(bool value) {
+void AnsiWrapper::setCursor(bool value) const {
     fprintf(m_outputFile, ANSI_ESC "?25%c", value ? 'h' : 'l');
 }
 
@@ -115,11 +115,11 @@ void AnsiWrapper::setOutputFile(FILE *file) {
     m_outputFile = file;
 }
 
-void AnsiWrapper::saveCursor() {
+void AnsiWrapper::saveCursor() const {
     fprintf(m_outputFile, "\x1b" "7");
 }
 
-void AnsiWrapper::restoreCursor() {
+void AnsiWrapper::restoreCursor() const {
     fprintf(m_outputFile, "\x1b" "8");
 }
 

--- a/src/ansi_wrapper.cpp
+++ b/src/ansi_wrapper.cpp
@@ -138,7 +138,7 @@ void AnsiWrapper::restoreTerm(void) {
     signal(SIGQUIT, SIG_DFL);
 }
 
-char outputBuffer[50000];
+static char outputBuffer[50000];
 
 void AnsiWrapper::initTerm(void) {
     setvbuf(m_outputFile, outputBuffer, _IOFBF, sizeof(outputBuffer));

--- a/src/ansi_wrapper.cpp
+++ b/src/ansi_wrapper.cpp
@@ -1,7 +1,9 @@
 #include "../include/ansi_wrapper.hpp"
 
+extern "C" {
 #include <sys/stat.h>
 #include <fcntl.h>
+}
 
 #define ANSI_ESC "\x1b["
 

--- a/src/config_json_reader.cpp
+++ b/src/config_json_reader.cpp
@@ -43,11 +43,11 @@ std::map<std::string, JsonReaderStrategy*> ConfigJsonReader::createOptions() {
     return options;
 }
 
-std::string& ConfigJsonReader::getError() {
+const std::string& ConfigJsonReader::getError() const {
     return m_error;
 }
 
-int ConfigJsonReader::getErrorLine() {
+int ConfigJsonReader::getErrorLine() const {
     return m_errorLine;
 }
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,6 +1,6 @@
 #include "../include/event.hpp"
 
-static const char *EVENT_NAMES[] = {
+static const char* const EVENT_NAMES[] = {
     "KEY_EVENT",
     "QUERY_CHANGE_EVENT",
     "NEW_ITEMS_EVENT",
@@ -11,6 +11,6 @@ static const char *EVENT_NAMES[] = {
     "QUIT_EVENT",
 };
 
-const char **getEventNames() {
+const char* const* getEventNames() {
     return EVENT_NAMES;
 }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,6 +1,6 @@
 #include "../include/event.hpp"
 
-const char *EVENT_NAMES[] = {
+static const char *EVENT_NAMES[] = {
     "KEY_EVENT",
     "QUERY_CHANGE_EVENT",
     "NEW_ITEMS_EVENT",

--- a/src/history_manager.cpp
+++ b/src/history_manager.cpp
@@ -48,7 +48,7 @@ bool HistoryManager::writeHistory(Item *selected) {
         try {
             fs::create_directories(parent);
         }
-        catch (std::exception) {
+        catch (const std::exception&) {
             fprintf(stderr,
                     "ERROR: could not create parent directories for '%s'\n",
                     expanded.c_str());

--- a/src/input_reader.cpp
+++ b/src/input_reader.cpp
@@ -17,7 +17,7 @@ using std::chrono::system_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
 
-std::map<std::string, Key> createKeyLookup() {
+static std::map<std::string, Key> createKeyLookup() {
     std::map<std::string, Key> lookup;
     lookup["A"] = K_UP;
     lookup["B"] = K_DOWN;
@@ -60,7 +60,7 @@ std::map<std::string, Key> createKeyLookup() {
 
     return lookup;
 }
-const std::map<std::string, Key> ESC_KEY_LOOKUP = createKeyLookup();
+static const std::map<std::string, Key> ESC_KEY_LOOKUP = createKeyLookup();
 
 int utf8CharLen(unsigned char ch) {
     if (ch < 128) {
@@ -334,7 +334,7 @@ int InputReader::parseUtf8(char ch, Key *key) {
     return true;
 }
 
-bool is_started = false;
+static bool is_started = false;
 
 void InputReader::onLoop() {
     if (!is_started) {

--- a/src/input_reader.cpp
+++ b/src/input_reader.cpp
@@ -1,16 +1,18 @@
 #include <cstdio>
-#include <stdio.h>
-#include <string.h>
-#include <termios.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <sys/select.h>
-#include <errno.h>
+#include <cstring>
+#include <cerrno>
 #include <sstream>
 #include <map>
 #include <iostream>
 #include <csignal>
-#include <cerrno>
+
+extern "C" {
+#include <termios.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <sys/select.h>
+}
+
 #include "../include/input_reader.hpp"
 
 using std::chrono::system_clock;

--- a/src/item_cache.cpp
+++ b/src/item_cache.cpp
@@ -16,11 +16,11 @@ Item* ItemCache::get(int i) {
     return m_cache.get(i);
 }
 
-int ItemCache::size() {
+int ItemCache::size() const {
     return m_cachedSize;
 }
 
-int ItemCache::getReserve() {
+int ItemCache::getReserve() const {
     return m_cache.getReserve();
 }
 

--- a/src/item_list.cpp
+++ b/src/item_list.cpp
@@ -7,7 +7,7 @@ ItemList::ItemList(FILE *outputFile, StyleManager *styleManager,
     m_itemCache = itemCache;
 }
 
-void ItemList::drawItems() {
+void ItemList::drawItems() const {
     if (m_width <= 2 || m_height <= 1) {
         return;
     }
@@ -28,7 +28,7 @@ void ItemList::drawItems() {
     }
 }
 
-void ItemList::drawName(int i) {
+void ItemList::drawName(int i) const {
     std::string name = std::string(m_itemCache->get(i)->text);
 
     if (name.size() > m_itemWidth) {
@@ -59,7 +59,7 @@ void ItemList::drawName(int i) {
     // fprintf(m_outputFile, "%s %d", name.c_str(), m_itemCache->get(i)->heuristic);
 }
 
-void ItemList::drawHint(int i) {
+void ItemList::drawHint(int i) const {
     char *text = m_itemCache->get(i)->text;
     std::string hint = std::string(text + strlen(text) + 1);
 
@@ -261,7 +261,7 @@ void ItemList::setSelected(int y) {
     }
 }
 
-Item* ItemList::get(int y) {
+Item* ItemList::get(int y) const {
     return m_itemCache->get(m_offset + y);
 }
 
@@ -305,7 +305,7 @@ void ItemList::refresh() {
     }
 }
 
-Item* ItemList::getSelected() {
+Item* ItemList::getSelected() const {
     if (m_nVisibleItems) {
         return m_itemCache->get(m_cursor);
     }

--- a/src/item_matcher.cpp
+++ b/src/item_matcher.cpp
@@ -8,13 +8,13 @@
 #define isalpha(c) (isupper(c) || islower(c))
 #define tolower(c) (isupper(c) ? c + 32 : c)
 
-const int MATCH_BONUS = 1;
-const int BOUNDARY_BONUS = 100;
-const int NEW_WORD_BONUS = 101;
-const int CONSECUTIVE_BONUS = 200;
-const int DISTANCE_PENALTY = -50;
+static const int MATCH_BONUS = 1;
+static const int BOUNDARY_BONUS = 100;
+static const int NEW_WORD_BONUS = 101;
+static const int CONSECUTIVE_BONUS = 200;
+static const int DISTANCE_PENALTY = -50;
 
-inline int boundaryScore(const char *c) {
+static inline int boundaryScore(const char *c) {
     if (islower(*c)) {
         if (!isalpha(*(c - 1))) {
             return NEW_WORD_BONUS;

--- a/src/item_sorter.cpp
+++ b/src/item_sorter.cpp
@@ -55,7 +55,7 @@ void ItemSorter::sort(int sortIdx) {
     m_sortIdx = sortIdx;
 }
 
-int ItemSorter::size() {
+int ItemSorter::size() const {
     return m_items.size();
 }
 

--- a/src/json_parser.cpp
+++ b/src/json_parser.cpp
@@ -401,7 +401,7 @@ bool JsonParser::parseNumber() {
         try {
             m_elements.push_back(new JsonInt(m_line, m_idx, std::stoi(value)));
         }
-        catch (std::out_of_range) {
+        catch (const std::out_of_range&) {
             m_error = "The number is out of range";
             return false;
         }

--- a/src/json_parser.cpp
+++ b/src/json_parser.cpp
@@ -3,11 +3,11 @@
 #include <fstream>
 
 
-JsonElementType JsonElement::getType() {
+JsonElementType JsonElement::getType() const {
     return m_type;
 }
 
-int JsonElement::getLine() {
+int JsonElement::getLine() const {
     return m_line;
 }
 
@@ -93,7 +93,7 @@ std::map<std::string, JsonObjectEntry>& JsonObject::getValue() {
 std::string JsonObject::repr(int indent, int depth) {
     std::string repr = "{";
 
-    for (auto it = m_value.begin(); it != m_value.end(); ++it) { 
+    for (auto it = m_value.begin(); it != m_value.end(); ++it) {
         if (indent) {
             repr += "\n";
             for (int i = 0; i < indent * (depth + 1); i++) {
@@ -138,7 +138,7 @@ std::string JsonArray::repr(int indent, int depth) {
     std::string repr = "[";
 
     std::vector<JsonElement*>::iterator it;
-    for (it = m_value.begin(); it != m_value.end(); ++it) { 
+    for (it = m_value.begin(); it != m_value.end(); ++it) {
         if (indent) {
             repr += "\n";
             for (int i = 0; i < indent * (depth + 1); i++) {
@@ -190,15 +190,15 @@ bool JsonParser::parse(std::string json) {
     return valid;
 }
 
-std::string JsonParser::getError() {
+std::string JsonParser::getError() const {
     return m_error;
 }
 
-int JsonParser::getLine() {
+int JsonParser::getLine() const {
     return m_line;
 }
 
-JsonElement* JsonParser::getElement() {
+JsonElement* JsonParser::getElement() const {
     return m_elements.size() ? m_elements.back() : nullptr;
 }
 

--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -1,10 +1,10 @@
 #include "../include/util.hpp"
 #include "../include/json_reader.hpp"
 
-std::string errorMsg;
-int errorLine = 0;
+static std::string errorMsg;
+static int errorLine = 0;
 
-void typeError(std::string name, std::string type) {
+static void typeError(std::string name, std::string type) {
     errorMsg = "The datatype for '" + name + "' must be "
         + (isVowel(type[0]) ? "an" : "a") + " " + type;
 }
@@ -237,7 +237,7 @@ bool JsonStylesReaderStrategy::readAttr(JsonArray *arr, AnsiStyle *style) {
     }
     auto value = arr->getValue();
 
-    for (int i = 0; i < value.size(); i++) { 
+    for (int i = 0; i < value.size(); i++) {
         if (value[i]->getType() != STRING) {
             errorMsg = "The datatype of an attr must be a string";
             errorLine = value[i]->getLine();
@@ -278,7 +278,7 @@ bool JsonStylesReaderStrategy::readAttr(JsonArray *arr, AnsiStyle *style) {
             return false;
         }
     }
-    
+
     return true;
 }
 

--- a/src/json_reader.cpp
+++ b/src/json_reader.cpp
@@ -286,7 +286,7 @@ JsonReader::JsonReader(std::map<std::string, JsonReaderStrategy*>& options) {
     m_options = options;
 }
 
-std::string& JsonReader::getError() {
+const std::string& JsonReader::getError() {
     return errorMsg;
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,5 +1,5 @@
 #include "../include/logger.hpp"
-#include <stdarg.h>
+#include <cstdarg>
 
 bool Logger::c_enabled;
 std::mutex Logger::c_mut;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,10 @@
 #include <thread>
 #include <climits>
 #include <cstring>
+#include <csignal>
+extern "C" {
 #include <fcntl.h>
-#include <signal.h>
+}
 
 static Config& config = Config::instance();
 static AnsiWrapper& ansi = AnsiWrapper::instance();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,10 +20,10 @@
 #include <fcntl.h>
 #include <signal.h>
 
-Config& config = Config::instance();
-AnsiWrapper& ansi = AnsiWrapper::instance();
-EventDispatch& eventDispatch = EventDispatch::instance();
-Logger logger = Logger("main");
+static Config& config = Config::instance();
+static AnsiWrapper& ansi = AnsiWrapper::instance();
+static EventDispatch& eventDispatch = EventDispatch::instance();
+static Logger logger = Logger("main");
 
 void printResult(Item *selected, const char *input) {
     if (selected) {

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -2,12 +2,12 @@
 #include "../include/util.hpp"
 #include <cstring>
 
-bool Option::error(std::string message) {
+bool Option::error(const std::string& message) const {
     printf("The '--%s' option %s\n", m_key.c_str(), message.c_str());
     return false;
 }
 
-const std::string& Option::getKey() {
+const std::string& Option::getKey() const {
     return m_key;
 }
 
@@ -17,7 +17,7 @@ BooleanOption::BooleanOption(std::string key, bool *value) {
     m_value = value;
     m_defaultValue = false;
 }
-        
+
 BooleanOption* BooleanOption::defaultTrue() {
     m_defaultValue = true;
     *m_value = true;
@@ -43,7 +43,7 @@ StringOption* StringOption::nonEmpty() {
     m_allowEmpty = false;
     return this;
 }
-        
+
 bool StringOption::parse(const char *value) {
     if (!value) {
         return error("expects a value");
@@ -70,7 +70,7 @@ IntegerOption* IntegerOption::max(int max) {
     m_max = max;
     return this;
 }
-        
+
 bool IntegerOption::parse(const char *value) {
     if (!isInteger(value)) {
         return error("expects an integer");

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -80,7 +80,7 @@ bool IntegerOption::parse(const char *value) {
     try {
         num = std::stoi(value);
     }
-    catch (std::out_of_range) {
+    catch (const std::out_of_range&) {
         return error("received an out of range integer");
     }
 

--- a/src/option_parser.cpp
+++ b/src/option_parser.cpp
@@ -1,6 +1,6 @@
 #include "../include/option_parser.hpp"
 
-std::vector<KeywordArg> parseKwargs(int argc, const char **argv) {
+static std::vector<KeywordArg> parseKwargs(int argc, const char **argv) {
     std::vector<KeywordArg> kwargs;
 
     for (int i = 1; i < argc; i++) {

--- a/src/spinner.cpp
+++ b/src/spinner.cpp
@@ -11,7 +11,7 @@ Spinner::Spinner(FILE *file) {
     m_outputFile = file;
 }
 
-milliseconds Spinner::frameTimeRemaining() {
+milliseconds Spinner::frameTimeRemaining() const {
     milliseconds remaining = 150ms - duration_cast<milliseconds>(
             system_clock::now() - m_lastFrameTime);
     if (remaining <= 0ms) {
@@ -36,14 +36,14 @@ void Spinner::update() {
     m_lastFrameTime = system_clock::now();
 }
 
-void Spinner::draw() {
+void Spinner::draw() const {
     if (m_firstUpdateComplete) {
         ansi.move(m_x, m_y);
         fprintf(m_outputFile, "%s", SPINNER[m_frame]);
     }
 }
 
-bool Spinner::isSpinning() {
+bool Spinner::isSpinning() const {
     return m_isSpinning;
 }
 

--- a/src/spinner.cpp
+++ b/src/spinner.cpp
@@ -4,8 +4,8 @@ using namespace std::chrono_literals;
 using std::chrono::milliseconds;
 using std::chrono::system_clock;
 
-const char *SPINNER[6] = {"⠇", "⠋", "⠙", "⠸", "⠴", "⠦"};
-const int SPINNER_SIZE = 6;
+static const char *SPINNER[6] = {"⠇", "⠋", "⠙", "⠸", "⠴", "⠦"};
+static const int SPINNER_SIZE = 6;
 
 Spinner::Spinner(FILE *file) {
     m_outputFile = file;

--- a/src/user_interface.cpp
+++ b/src/user_interface.cpp
@@ -222,7 +222,7 @@ void UserInterface::onEvent(std::shared_ptr<Event> event) {
     }
 }
 
-Item* UserInterface::getSelected() {
+Item* UserInterface::getSelected() const {
     if (m_selected) {
         return m_itemList->getSelected();
     }

--- a/src/utf8_line_editor.cpp
+++ b/src/utf8_line_editor.cpp
@@ -54,7 +54,7 @@ void Utf8LineEditor::clear() {
     m_end.reset();
 }
 
-std::string& Utf8LineEditor::getText() {
+const std::string& Utf8LineEditor::getText() const {
     return m_string.bytes;
 }
 
@@ -75,7 +75,7 @@ void Utf8LineEditor::adjustBounds() {
     while (m_start.getCol() + m_width < m_end.getCol() && m_end.moveLeft());
 }
 
-bool Utf8LineEditor::requiresRedraw() {
+bool Utf8LineEditor::requiresRedraw() const {
     return m_requiresRedraw;
 }
 
@@ -100,6 +100,6 @@ void Utf8LineEditor::setWidth(int width) {
     m_width = width - 1;
 }
 
-int Utf8LineEditor::getCursorCol() {
+int Utf8LineEditor::getCursorCol() const {
     return m_cursor.getCol() - m_start.getCol();
 }

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -131,18 +131,18 @@ int Utf8StringCursor::getBytesForCols(int cols) {
     return bytes;
 }
 
-int Utf8StringCursor::getByte() {
+int Utf8StringCursor::getByte() const {
     return m_byteIdx;
 }
 
-int Utf8StringCursor::getIdx() {
+int Utf8StringCursor::getIdx() const {
     return m_charIdx;
 }
 
-int Utf8StringCursor::getCol() {
+int Utf8StringCursor::getCol() const {
     return m_cellIdx;
 }
 
-const char* Utf8StringCursor::getPointer() {
+const char* Utf8StringCursor::getPointer() const {
     return m_str->bytes.c_str() + m_byteIdx;
 }

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -46,7 +46,7 @@ void Utf8StringCursor::insert(std::string& str) {
             try {
                 ws = converter.from_bytes(widechar);
             }
-            catch (std::range_error) {
+            catch (const std::range_error&) {
                 continue;
             }
 

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -3,7 +3,7 @@
 #include <locale>
 #include <codecvt>
 
-std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+static std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
 
 void Utf8StringCursor::setString(Utf8String *str) {
     m_str = str;


### PR DESCRIPTION
### refactor: use static

Generally everything that is declared and visible only in a single
translation unit (.cpp file) should be marked as static. First of all,
this avoids linker errors (one definition rule violations) if you have
symbols with the same name defined in multiple files. Second, it enables
more optimizations. The compiler is only aware of what's happening in a
single file at the time, and static gives it a hint that it can be
optimized in the context of that particular file.

### refactor: mark member functions as const

Methods that don't modify the class can be marked as const. This enables
more optimizations. When for example a getter function is called
multiple times in a row, the compiler can use that information and call
that function only once.

### refactor: use override

Use "override" keyword when overriding virtual methods. This is useful
during refactoring when you want to change the signature of a virtual
function. Any overridden function that doesn't match the signature will
be a compiler error.

### refactor: C header includes

Use the C++ versions of C headers and wrap other system headers in
extern "C". During compilation symbol names in C++ are "mangled" to
include type information. C doesn't do this, so if you have a
declaration in both C and C++ that seems to look exactly the same, C++
might not connect the dots that this is supposed to be the same
function. This isn't usually a problem with libc and system headers, but
still it's more correct to wrap the declarations of C functions in
extern "C" block. C++ versions of C headers (stdio.h -> cstdio) do this
for you.

### refactor: catch exceptions by const reference

Exceptions should be caught by const reference. Passing them by value
force a copy, which might throw another exception and I think this would
be undefined behavior. Exceptions also use inheritance and if just
the base class is copied, the actual derived exception is discarded.