### PR TITLE
fix: mouse not restored on exit

### DIFF
--- a/src/ansi_wrapper.cpp
+++ b/src/ansi_wrapper.cpp
@@ -77,7 +77,7 @@ void AnsiWrapper::enableMouse() {
 void AnsiWrapper::disableMouse() {
     if (m_mouseEnabled) {
         m_mouseEnabled = false;
-        fprintf(m_outputFile, ANSI_ESC "?1000l");
+        fprintf(m_outputFile, ANSI_ESC "?1002l" ANSI_ESC "?1015l" ANSI_ESC "?1006l");
     }
 }
 


### PR DESCRIPTION
disableMouse didn't match enableMouse, and mouse was still enabled after exitting the program.