### PR TITLE
Include missing header file

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1,5 +1,5 @@
 #include "../include/process.hpp"
-
+#include <cstdlib>
 #include <csignal>
 
 #define READ 0


### PR DESCRIPTION
- Include cstdlib header in process.cpp

Before this patch:

```log
make -j 4
[  2%] Building CXX object CMakeFiles/jfind.dir/src/json_parser.cpp.o
[  5%] Building CXX object CMakeFiles/jfind.dir/src/key.cpp.o
[  8%] Building CXX object CMakeFiles/jfind.dir/src/logger.cpp.o
[ 11%] Building CXX object CMakeFiles/jfind.dir/src/json_reader.cpp.o
[ 13%] Building CXX object CMakeFiles/jfind.dir/src/main.cpp.o
[ 16%] Building CXX object CMakeFiles/jfind.dir/src/option.cpp.o
[ 19%] Building CXX object CMakeFiles/jfind.dir/src/option_parser.cpp.o
[ 22%] Building CXX object CMakeFiles/jfind.dir/src/process.cpp.o
/tmp/jfind/src/process.cpp: In member function ‘bool Process::start(char* const*)’:
/tmp/jfind/src/process.cpp:30:14: error: ‘EXIT_FAILURE’ was not declared in this scope
   30 |         exit(EXIT_FAILURE);
      |              ^~~~~~~~~~~~
/tmp/jfind/src/process.cpp:4:1: note: ‘EXIT_FAILURE’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
    3 | #include <csignal>
  +++ |+#include <cstdlib>
    4 |
/tmp/jfind/src/process.cpp:30:9: error: ‘exit’ was not declared in this scope
   30 |         exit(EXIT_FAILURE);
      |         ^~~~
/tmp/jfind/src/process.cpp:30:9: note: ‘exit’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
/tmp/jfind/src/process.cpp:43:19: error: ‘EXIT_FAILURE’ was not declared in this scope
   43 |             _exit(EXIT_FAILURE);
      |                   ^~~~~~~~~~~~
/tmp/jfind/src/process.cpp:43:19: note: ‘EXIT_FAILURE’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
/tmp/jfind/src/process.cpp:47:15: error: ‘EXIT_FAILURE’ was not declared in this scope
   47 |         _exit(EXIT_FAILURE);
      |               ^~~~~~~~~~~~
/tmp/jfind/src/process.cpp:47:15: note: ‘EXIT_FAILURE’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
/tmp/jfind/src/process.cpp:54:14: error: ‘EXIT_FAILURE’ was not declared in this scope
   54 |         exit(EXIT_FAILURE);
      |              ^~~~~~~~~~~~
/tmp/jfind/src/process.cpp:54:14: note: ‘EXIT_FAILURE’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
/tmp/jfind/src/process.cpp:54:9: error: ‘exit’ was not declared in this scope
   54 |         exit(EXIT_FAILURE);
      |         ^~~~
/tmp/jfind/src/process.cpp:54:9: note: ‘exit’ is defined in header ‘<cstdlib>’; did you forget to ‘#include <cstdlib>’?
make[2]: *** [CMakeFiles/jfind.dir/build.make:454: CMakeFiles/jfind.dir/src/process.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/jfind.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```


After this patch:

```log
make -j 4
[  2%] Building CXX object CMakeFiles/jfind.dir/src/process.cpp.o
[  5%] Building CXX object CMakeFiles/jfind.dir/src/process_item_reader.cpp.o
[  8%] Building CXX object CMakeFiles/jfind.dir/src/style_manager.cpp.o
[ 11%] Building CXX object CMakeFiles/jfind.dir/src/spinner.cpp.o
[ 13%] Building CXX object CMakeFiles/jfind.dir/src/user_interface.cpp.o
[ 16%] Building CXX object CMakeFiles/jfind.dir/src/utf8_line_editor.cpp.o
[ 19%] Building CXX object CMakeFiles/jfind.dir/src/utf8_string.cpp.o
[ 22%] Building CXX object CMakeFiles/jfind.dir/src/util.cpp.o
[ 25%] Linking CXX executable jfind
[100%] Built target jfind
```
